### PR TITLE
Update demon_core_assets_v1.1.cfg

### DIFF
--- a/demon_core_assets_v1.1.cfg
+++ b/demon_core_assets_v1.1.cfg
@@ -928,6 +928,7 @@ gcode:
         STATUS_LEVELING
       {% endif %}
       QUAD_GANTRY_LEVEL 
+     M400
     
     {% elif printer.configfile.settings.printer.kinematics == 'cartesian' and ('z_tilt' in printer.configfile.config) %}
       SET_DISPLAY_TEXT MSG="Gantry Levelling" 


### PR DESCRIPTION
Added M400 due to cartographer3d throws an error without it present. (after gantry level) "Toolhead stopped below model range"