### PR TITLE
Update demon_print_start_end_v2.9.cfg

### DIFF
--- a/demon_print_start_end_v2.9.cfg
+++ b/demon_print_start_end_v2.9.cfg
@@ -318,6 +318,7 @@ gcode:
 
     {% else %}
       BED_MESH_CALIBRATE ADAPTIVE=1 ADAPTIVE_MARGIN=10
+      CARTOGRAPHER_TOUCH
     {% endif %}
   {% endif %}
 


### PR DESCRIPTION
Added cartographer "Perform touch probe"
Maybe there is a better spot for it, but it does work.
My guess would be that its best to have it as an true/false option in userconfig, or have a check if it is present.

Also some people only use the scanner function of cartographer, but i think most use "touch" as well since its so awesome.

https://docs.cartographer3d.com/cartographer-probe/installation-and-setup/touch-installation/print-start-macro