### PR TITLE
Update demon_user_settings_cleaner_variables_v1.1.0.cfg

### DIFF
--- a/Other_Files/DEMON_User_Files_SOURCE/demon_user_settings_cleaner_variables_v1.1.0.cfg
+++ b/Other_Files/DEMON_User_Files_SOURCE/demon_user_settings_cleaner_variables_v1.1.0.cfg
@@ -64,7 +64,7 @@ variable_linear_clean_start_z: 4                 # Linear start cleaning postion
 variable_linear_clean_axis: "X"                  # Set to clean along X or Y axes - DONT GET THIS WRONG! Option must be inside quotation marks ("X" or "Y")
 variable_linear_clean_positive_dir: False        # Set to True to clean in a positive direction away from your start position, set False for negative
 
-variable_linear_clean_distance: 50               # Set how far to move the nozzle from your start position to suit your cleaning pad/brush - for stock setup use 218
+variable_linear_clean_distance: 50               # Set how far to move the nozzle from your start position to suit your cleaning pad/brush - for stock setup use 28
 
 ## NOTE: With linear_clean_axis set to X. To move the toolhead right from your start position set linear_clean_positive_dir to True. To move it left set it to False
 ## NOTE: With linear_clean_axis set to Y. To move the toolhead towards you from your start position set linear_clean_positive_dir to False. To move it away set it to True

--- a/Other_Files/DEMON_User_Files_SOURCE/demon_user_settings_cleaner_variables_v1.1.0.cfg
+++ b/Other_Files/DEMON_User_Files_SOURCE/demon_user_settings_cleaner_variables_v1.1.0.cfg
@@ -42,12 +42,12 @@ variable_random_clean_y: True                    # Choose random or linear clean
 variable_clean_travel_speed: 200                 # Set Speed to travel to cleaning start position in mm/s
 variable_pass_spd: 250                           # Set cleaning pass speed in mm/s
 
-variable_end_position_x: 323                     # End cleaning position for X - SV08 Demon Purge Bucket X 320, or for stock setup use 351
-variable_end_position_y: 347                     # End cleaning position for Y - SV08 Demon Purge Bucket Y 359, or for stock setup use 359
+variable_end_position_x: 323                     # End cleaning position for X - SV08 Demon Purge Bucket X 320, or for stock setup use 315
+variable_end_position_y: 347                     # End cleaning position for Y - SV08 Demon Purge Bucket Y 359, or for stock setup use 360
 
-variable_park_x: 323                             # - SV08 Demon Purge Bucket X 344
-variable_park_y: 340                             # - SV08 Demon Purge Bucket Y 345
-variable_park_z: 25                              # - SV08 Demon Purge Bucket Z 25
+variable_park_x: 323                             # - SV08 Demon Purge Bucket X 344, or for stock setup use 324
+variable_park_y: 340                             # - SV08 Demon Purge Bucket Y 345, or for stock setup use 360
+variable_park_z: 25                              # - SV08 Demon Purge Bucket Z 25, or for stock setup use 10
 
 ## NOTE: To use Full linear cleaning mode set both random_clean_x & y options above to False!
 ## NOTE: If you set just one axis to linear mode but leave the other as radnom the priority settings are given to Random Cleaning Mode & 
@@ -57,14 +57,14 @@ variable_park_z: 25                              # - SV08 Demon Purge Bucket Z 2
 
 variable_linear_pass_count: 6                    # Number of cleaning pass actions
 
-variable_linear_clean_start_x: 305               # Linear start cleaning postion for X axis
-variable_linear_clean_start_y: 347               # Linear start cleaning postion for Y axis
-variable_linear_clean_start_z: 4                 # Linear start cleaning postion for Z axis - CLEANING HEIGHT!
+variable_linear_clean_start_x: 305               # Linear start cleaning postion for X axis, for stock setup use 315
+variable_linear_clean_start_y: 347               # Linear start cleaning postion for Y axis, for stock setup use 360
+variable_linear_clean_start_z: 4                 # Linear start cleaning postion for Z axis, for stock setup use 0.2 - CLEANING HEIGHT!
 
 variable_linear_clean_axis: "X"                  # Set to clean along X or Y axes - DONT GET THIS WRONG! Option must be inside quotation marks ("X" or "Y")
 variable_linear_clean_positive_dir: False        # Set to True to clean in a positive direction away from your start position, set False for negative
 
-variable_linear_clean_distance: 50               # Set how far to move the nozzle from your start position to suit your cleaning pad/brush 
+variable_linear_clean_distance: 50               # Set how far to move the nozzle from your start position to suit your cleaning pad/brush - for stock setup use 218
 
 ## NOTE: With linear_clean_axis set to X. To move the toolhead right from your start position set linear_clean_positive_dir to True. To move it left set it to False
 ## NOTE: With linear_clean_axis set to Y. To move the toolhead towards you from your start position set linear_clean_positive_dir to False. To move it away set it to True
@@ -73,14 +73,14 @@ variable_linear_clean_distance: 50               # Set how far to move the nozzl
 
 variable_pass_count: 40                          # Number of cleaning pass actions - needs much higher value than linear mode
 
-variable_start_x: 305                            # Start cleaning postion for X - SV08 Demon Purge Bucket X 294, or for stock setup use 316 
-variable_start_y: 347                            # Start cleaning postion for Y - SV08 Demon Purge Bucket Y 359, or for stock setup use 359
-variable_start_z: 4                              # Start cleaning postion for Z - SV08 Demon Purge Bucket Z 3, or for stock setup use 0.5
+variable_start_x: 305                            # Start cleaning postion for X - SV08 Demon Purge Bucket X 294, or for stock setup use 315 
+variable_start_y: 347                            # Start cleaning postion for Y - SV08 Demon Purge Bucket Y 359, or for stock setup use 360
+variable_start_z: 4                              # Start cleaning postion for Z - SV08 Demon Purge Bucket Z 3, or for stock setup use 0.2
 
-variable_clean_min_x: 260                        # Min safe X axis for random clean movements - SV08 Demon Purge Bucket Xmin 303
-variable_clean_max_x: 303                        # Max safe X axis for random clean movements - SV08 Demon Purge Bucket Xmax 335
-variable_clean_min_y: 346                        # Min safe Y axis for random clean movements - SV08 Demon Purge Bucket Ymin 356
-variable_clean_max_y: 352                        # Max safe Y axis for random clean movements - SV08 Demon Purge Bucket Ymax 362
+variable_clean_min_x: 260                        # Min safe X axis for random clean movements - SV08 Demon Purge Bucket Xmin 303, or for stock setup use 324
+variable_clean_max_x: 303                        # Max safe X axis for random clean movements - SV08 Demon Purge Bucket Xmax 335, or for stock setup use 345
+variable_clean_min_y: 346                        # Min safe Y axis for random clean movements - SV08 Demon Purge Bucket Ymin 356, or for stock setup use 358
+variable_clean_max_y: 352                        # Max safe Y axis for random clean movements - SV08 Demon Purge Bucket Ymax 362, or for stock setup use 360
 
 ## PURGE BUCKET SETTINGS ###########################################################################################################################
 


### PR DESCRIPTION
SV08 Stock variables (, or for stock setup use ...) adapted to the default values taken from the original Sovol “clean_nozzle” macro