### PR TITLE
Remove 'pi' username dependency from User_Files_Updater

### DIFF
--- a/Other_Files/Demon_User_Files_Updater/Extract_Demon_User_Files_Rpi.cfg
+++ b/Other_Files/Demon_User_Files_Updater/Extract_Demon_User_Files_Rpi.cfg
@@ -1,5 +1,5 @@
 [gcode_shell_command demon_user_settings_file_extract]
-command: /usr/bin/bash /home/pi/printer_data/config/Demon_Klipper_Essentials_Unified/Other_Files/Demon_User_Files_Updater/Demon_User_Settings.sh
+command: /usr/bin/bash ~/printer_data/config/Demon_Klipper_Essentials_Unified/Other_Files/Demon_User_Files_Updater/Demon_User_Settings.sh
 timeout: 10
 verbose: True
 
@@ -32,7 +32,7 @@ gcode:
 
 
 [gcode_shell_command demon_user_cleaner_file_extract]
-command: /usr/bin/bash /home/pi/printer_data/config/Demon_Klipper_Essentials_Unified/Other_Files/Demon_User_Files_Updater/Demon_User_Cleaner.sh
+command: /usr/bin/bash ~/printer_data/config/Demon_Klipper_Essentials_Unified/Other_Files/Demon_User_Files_Updater/Demon_User_Cleaner.sh
 timeout: 10
 verbose: True
 
@@ -65,7 +65,7 @@ gcode:
 
 
 [gcode_shell_command demon_user_expansion_file_extract]
-command: /usr/bin/bash /home/pi/printer_data/config/Demon_Klipper_Essentials_Unified/Other_Files/Demon_User_Files_Updater/Demon_User_Expansion.sh
+command: /usr/bin/bash ~/printer_data/config/Demon_Klipper_Essentials_Unified/Other_Files/Demon_User_Files_Updater/Demon_User_Expansion.sh
 timeout: 10
 verbose: True
 
@@ -97,7 +97,7 @@ gcode:
 
 
 [gcode_shell_command demon_prepare_user_files]
-command: /usr/bin/bash /home/pi/printer_data/config/Demon_Klipper_Essentials_Unified/Other_Files/Demon_User_Files_Updater/First_Boot_Demon_User_Files.sh
+command: /usr/bin/bash ~/printer_data/config/Demon_Klipper_Essentials_Unified/Other_Files/Demon_User_Files_Updater/First_Boot_Demon_User_Files.sh
 timeout: 10
 verbose: True
 
@@ -131,7 +131,7 @@ gcode:
     
 
 [gcode_shell_command demon_vars_file_extract]
-command: /usr/bin/bash /home/pi/printer_data/config/Demon_Klipper_Essentials_Unified/Other_Files/Demon_User_Files_Updater/Demon_Vars_Updater.sh
+command: /usr/bin/bash ~/printer_data/config/Demon_Klipper_Essentials_Unified/Other_Files/Demon_User_Files_Updater/Demon_Vars_Updater.sh
 timeout: 10
 verbose: True
 
@@ -268,7 +268,7 @@ gcode:
 
 
 [gcode_shell_command disk_space_check]
-command: /usr/bin/bash /home/pi/printer_data/config/Demon_Klipper_Essentials_Unified/Other_Files/Demon_User_Files_Updater/Demon_Disk_Space_Checker.sh
+command: /usr/bin/bash ~/printer_data/config/Demon_Klipper_Essentials_Unified/Other_Files/Demon_User_Files_Updater/Demon_Disk_Space_Checker.sh
 timeout: 10
 verbose: True
 


### PR DESCRIPTION
Pi installation now can customise the username - best to use ~ to address the file location of the .sh scripts rather than /home/pi hard coded.