### PR TITLE
Allow bed scan without qgl or tilt on corexy

### DIFF
--- a/demon_core_assets_v1.4.0.cfg
+++ b/demon_core_assets_v1.4.0.cfg
@@ -1510,7 +1510,10 @@ gcode:
       QUAD_GANTRY_LEVEL 
       M400
     
-    {% elif printer.configfile.settings.printer.kinematics == 'cartesian' and ('z_tilt' in printer.configfile.config) %}
+    {% elif printer.configfile.settings.printer.kinematics == 'corexy' and ('quad_gantry_level' not in printer.configfile.config) and ('z_tilt' not in printer.configfile.config)%}
+      RESPOND TYPE=COMMAND MSG="Levelling system not available, skipping Gantry Levelling"
+    
+    {% elif printer.configfile.settings.printer.kinematics == 'cartesian' and ('z_tilt' in printer.configfile.config)  %}
       SET_DISPLAY_TEXT MSG="Gantry Levelling" 
       RESPOND TYPE=COMMAND MSG="Gantry Levelling"  
       {% if start_vars.neopixel_led == True %}

--- a/demon_core_assets_v1.4.0.cfg
+++ b/demon_core_assets_v1.4.0.cfg
@@ -1510,7 +1510,7 @@ gcode:
       QUAD_GANTRY_LEVEL 
       M400
     
-    {% elif printer.configfile.settings.printer.kinematics == 'corexy' and ('quad_gantry_level' not in printer.configfile.config) and ('z_tilt' not in printer.configfile.config)%}
+    {% elif printer.configfile.settings.printer.kinematics == 'corexy' and ('quad_gantry_level' not in printer.configfile.config) and ('z_tilt' not in printer.configfile.config) %}
       RESPOND TYPE=COMMAND MSG="Levelling system not available, skipping Gantry Levelling"
     
     {% elif printer.configfile.settings.printer.kinematics == 'cartesian' and ('z_tilt' in printer.configfile.config)  %}


### PR DESCRIPTION
I came to a printer with Eddy and no QGL and no tilt and the scan was failing, I think it should be allow.

please advise.

Regards