### PR TITLE
Choose if using PA and Flow Rate from slicer instead of filament variables

### DIFF
--- a/Other_Files/DEMON_User_Files_SOURCE/demon_user_settings_v2.9.5.cfg
+++ b/Other_Files/DEMON_User_Files_SOURCE/demon_user_settings_v2.9.5.cfg
@@ -31,6 +31,8 @@ variable_eddy_park_y: 170                        # Set the most stable place on 
 
 variable_z_tracker_reduced_monitoring: False     # Set True to reduce Z Tracker monitoring if system performance is impacted, stored Z values will be less accurate
 
+variable_set_pa_and_flow_rate_variables: True    # Set True to use PA and Flow Rate variables by filament type. False to use the slicer values.
+
 # WARNING: Reducing Z Tracker monitoring with impede the functionality of the watchdog - printing heights & manual moves will not be recorded, only
 # specific moves & actions will be monitored.
 

--- a/demon_core_assets_v1.4.2.cfg
+++ b/demon_core_assets_v1.4.2.cfg
@@ -149,66 +149,74 @@ gcode:
    
     M220 S{start_vars.feed_rate}
  
-  {% if core_vars.filament in ['PLA', 'PLA+'] and core_vars.layer|float <0.25%}
-    {% if start_vars.disable_set_flow != True %}
-      M221 S{start_vars.pla_flow_rate}
-    {% endif %}
-    SET_PRESSURE_ADVANCE ADVANCE={start_vars.pla_pa} SMOOTH_TIME={start_vars.pla_st}
+  {% if start_vars.set_pa_and_flow_rate_variables == True %}
 
-  {% elif core_vars.filament == 'ASA' and core_vars.layer|float <0.25%}
-    {% if start_vars.disable_set_flow != True %}
-      M221 S{start_vars.asa_flow_rate}
-    {% endif %}
-    SET_PRESSURE_ADVANCE ADVANCE={start_vars.asa_pa} SMOOTH_TIME={start_vars.asa_st}
+    {% if core_vars.filament in ['PLA', 'PLA+'] and core_vars.layer|float <0.25%}
+      {% if start_vars.disable_set_flow != True %}
+        M221 S{start_vars.pla_flow_rate}
+      {% endif %}
+      SET_PRESSURE_ADVANCE ADVANCE={start_vars.pla_pa} SMOOTH_TIME={start_vars.pla_st}
 
-  {% elif core_vars.filament == 'ABS' and core_vars.layer|float <0.25%}
-    {% if start_vars.disable_set_flow != True %}
-      M221 S{start_vars.abs_flow_rate}
-    {% endif %}
-    SET_PRESSURE_ADVANCE ADVANCE={start_vars.abs_pa} SMOOTH_TIME={start_vars.abs_st}
+    {% elif core_vars.filament == 'ASA' and core_vars.layer|float <0.25%}
+      {% if start_vars.disable_set_flow != True %}
+        M221 S{start_vars.asa_flow_rate}
+      {% endif %}
+      SET_PRESSURE_ADVANCE ADVANCE={start_vars.asa_pa} SMOOTH_TIME={start_vars.asa_st}
 
-  {% elif core_vars.filament in ['PET', 'PETG'] and core_vars.layer|float <0.25%}
-    {% if start_vars.disable_set_flow != True %}
-      M221 S{start_vars.petg_flow_rate}
-    {% endif %}
-    SET_PRESSURE_ADVANCE ADVANCE={start_vars.petg_pa} SMOOTH_TIME={start_vars.petg_st}   
+    {% elif core_vars.filament == 'ABS' and core_vars.layer|float <0.25%}
+      {% if start_vars.disable_set_flow != True %}
+        M221 S{start_vars.abs_flow_rate}
+      {% endif %}
+      SET_PRESSURE_ADVANCE ADVANCE={start_vars.abs_pa} SMOOTH_TIME={start_vars.abs_st}
 
-  {% elif core_vars.filament in ['FLEX', 'TPU'] and core_vars.layer|float <0.25%}
-    {% if start_vars.disable_set_flow != True %}
-      M221 S{start_vars.tpu_flow_rate}
-    {% endif %}
-    SET_PRESSURE_ADVANCE ADVANCE={start_vars.tpu_pa} SMOOTH_TIME={start_vars.tpu_st}  
+    {% elif core_vars.filament in ['PET', 'PETG'] and core_vars.layer|float <0.25%}
+      {% if start_vars.disable_set_flow != True %}
+        M221 S{start_vars.petg_flow_rate}
+      {% endif %}
+      SET_PRESSURE_ADVANCE ADVANCE={start_vars.petg_pa} SMOOTH_TIME={start_vars.petg_st}   
 
-  {% elif core_vars.filament in ['PLA', 'PLA+'] and core_vars.layer|float >0.26%}
-    {% if start_vars.disable_set_flow != True %}
-      M221 S{start_vars.pla_hi_flow_rate}
-    {% endif %}
-    SET_PRESSURE_ADVANCE ADVANCE={start_vars.pla_pa} SMOOTH_TIME={start_vars.pla_st}
+    {% elif core_vars.filament in ['FLEX', 'TPU'] and core_vars.layer|float <0.25%}
+      {% if start_vars.disable_set_flow != True %}
+        M221 S{start_vars.tpu_flow_rate}
+      {% endif %}
+      SET_PRESSURE_ADVANCE ADVANCE={start_vars.tpu_pa} SMOOTH_TIME={start_vars.tpu_st}  
 
-  {% elif core_vars.filament == 'ASA' and core_vars.layer|float >0.26%}
-    {% if start_vars.disable_set_flow != True %}
-      M221 S{start_vars.asa_hi_flow_rate}
-    {% endif %}
-    SET_PRESSURE_ADVANCE ADVANCE={start_vars.asa_pa} SMOOTH_TIME={start_vars.asa_st}
+    {% elif core_vars.filament in ['PLA', 'PLA+'] and core_vars.layer|float >0.26%}
+      {% if start_vars.disable_set_flow != True %}
+        M221 S{start_vars.pla_hi_flow_rate}
+      {% endif %}
+      SET_PRESSURE_ADVANCE ADVANCE={start_vars.pla_pa} SMOOTH_TIME={start_vars.pla_st}
 
-  {% elif core_vars.filament == 'ABS' and core_vars.layer|float >0.26%}
-    {% if start_vars.disable_set_flow != True %}
-      M221 S{start_vars.abs_hi_flow_rate}
-    {% endif %}
-    SET_PRESSURE_ADVANCE ADVANCE={start_vars.abs_pa} SMOOTH_TIME={start_vars.abs_st}
+    {% elif core_vars.filament == 'ASA' and core_vars.layer|float >0.26%}
+      {% if start_vars.disable_set_flow != True %}
+        M221 S{start_vars.asa_hi_flow_rate}
+      {% endif %}
+      SET_PRESSURE_ADVANCE ADVANCE={start_vars.asa_pa} SMOOTH_TIME={start_vars.asa_st}
 
-  {% elif core_vars.filament in ['PET', 'PETG'] and core_vars.layer|float >0.26%}
-    {% if start_vars.disable_set_flow != True %}
-      M221 S{start_vars.petg_hi_flow_rate}
-    {% endif %}
-    SET_PRESSURE_ADVANCE ADVANCE={start_vars.petg_pa} SMOOTH_TIME={start_vars.petg_st}
-   
-  {% elif core_vars.filament in ['FLEX', 'TPU'] and core_vars.layer|float >0.26%}
-    {% if start_vars.disable_set_flow != True %}
-      M221 S{start_vars.tpu_hi_flow_rate}
-    {% endif %}
-    SET_PRESSURE_ADVANCE ADVANCE={start_vars.tpu_pa} SMOOTH_TIME={start_vars.tpu_st}  
+    {% elif core_vars.filament == 'ABS' and core_vars.layer|float >0.26%}
+      {% if start_vars.disable_set_flow != True %}
+        M221 S{start_vars.abs_hi_flow_rate}
+      {% endif %}
+      SET_PRESSURE_ADVANCE ADVANCE={start_vars.abs_pa} SMOOTH_TIME={start_vars.abs_st}
 
+    {% elif core_vars.filament in ['PET', 'PETG'] and core_vars.layer|float >0.26%}
+      {% if start_vars.disable_set_flow != True %}
+        M221 S{start_vars.petg_hi_flow_rate}
+      {% endif %}
+      SET_PRESSURE_ADVANCE ADVANCE={start_vars.petg_pa} SMOOTH_TIME={start_vars.petg_st}
+    
+    {% elif core_vars.filament in ['FLEX', 'TPU'] and core_vars.layer|float >0.26%}
+      {% if start_vars.disable_set_flow != True %}
+        M221 S{start_vars.tpu_hi_flow_rate}
+      {% endif %}
+      SET_PRESSURE_ADVANCE ADVANCE={start_vars.tpu_pa} SMOOTH_TIME={start_vars.tpu_st}  
+
+    {% endif %}
+
+  {% else %}
+
+    RESPOND TYPE=COMMAND MSG="Using flow rate and pa from slicer instead of filament variables"
+  
   {% endif %}
 
 


### PR DESCRIPTION
Hi friend. I hope everything is okay.

This change is proposed because many people prefer to use the laminator's PA and flow rate values ​​instead of the values ​​specified in the variables defined for them. For example, I use a different PA for two PLAs from different brands, and with the current macro configuration, this isn't possible.

Therefore, I'm adding a variable to control this. By default, it will continue to work as it has been, but it gives the option to set it to False to use the laminator's PA and flow rate values. I've been using it for a few months now, and it works like a charm. What do you think?

Thank you very much.