### PR TITLE
_FIL_CHANGE_PARK will do an UNLOAD_FILAMENT

### DIFF
--- a/Other_Files/DEMON_User_Files_SOURCE/demon_custom_expansion_v1.0.1.cfg
+++ b/Other_Files/DEMON_User_Files_SOURCE/demon_custom_expansion_v1.0.1.cfg
@@ -78,6 +78,12 @@ variable_pre_pid_tune_mode: False
 variable_post_pid_tune_mode: False
 
 ###################################################################################################################################################
+## PARK EXPANSION ################################################################################################################
+
+variable_pre_fil_change_park: False
+variable_post_fil_change_park: False
+
+###################################################################################################################################################
 ## PAUSE, RESUME & CANCEL EXPANSION ###############################################################################################################
 
 variable_pause: False
@@ -203,6 +209,16 @@ gcode:
 
 
 [gcode_macro _CUSTOM_POST_PID_Tune_Mode] # After PID_Tune_Mode macro runs - but before saving config
+gcode:
+
+
+
+[gcode_macro _CUSTOM_PRE_FIL_CHANGE_PARK] # Before _FIL_CHANGE_PARK macro runs
+gcode:
+
+
+
+[gcode_macro _CUSTOM_POST_FIL_CHANGE_PARK] # After _FIL_CHANGE_PARK macro runs
 gcode:
 
 

--- a/demon_core_assets_v1.4.2.cfg
+++ b/demon_core_assets_v1.4.2.cfg
@@ -1683,12 +1683,25 @@ gcode:
 [gcode_macro _FIL_CHANGE_PARK]
 gcode: 
   {% set start_vars = printer["gcode_macro _START_VARIABLES"] %}
+  {% set ceal = printer["gcode_macro CUSTOM_EXPANSION_ACTIVE_LIST"] %}
 
-    SET_DISPLAY_TEXT MSG="Moving to filament change position, use load macros when ready!"
-    RESPOND TYPE=COMMAND MSG="Moving to filament change position, use load macros when ready!"
-    PAUSE X={start_vars.filament_change_park_x} Y={start_vars.filament_change_park_y} Z_MIN={start_vars.filament_change_park_min_z} RESTORE=0
-    _SAVE
-    UNLOAD_FILAMENT
+  {% if ceal.ceal_master_enable == True %}
+    {% if ceal.pre_fil_change_park == True %}
+      _CUSTOM_PRE_FIL_CHANGE_PARK {rawparams}
+    {% endif %}
+  {% endif %}
+
+  SET_DISPLAY_TEXT MSG="Moving to filament change position, use load/unload macros when ready!"
+  RESPOND TYPE=COMMAND MSG="Moving to filament change position, use load/unload macros when ready!"
+  PAUSE X={start_vars.filament_change_park_x} Y={start_vars.filament_change_park_y} Z_MIN={start_vars.filament_change_park_min_z} RESTORE=0
+  _SAVE
+
+  {% if ceal.ceal_master_enable == True %}
+    {% if ceal.post_fil_change_park == True %}
+      _CUSTOM_POST_FIL_CHANGE_PARK {rawparams}
+    {% endif %}
+  {% endif %}
+
 
 [gcode_macro _MAX_EXTRUDE_CHECK]
 gcode:

--- a/demon_core_assets_v1.4.2.cfg
+++ b/demon_core_assets_v1.4.2.cfg
@@ -1684,11 +1684,11 @@ gcode:
 gcode: 
   {% set start_vars = printer["gcode_macro _START_VARIABLES"] %}
 
-    SET_DISPLAY_TEXT MSG="Moving to filament change position, use load/unload macros when ready!"
-    RESPOND TYPE=COMMAND MSG="Moving to filament change position, use load/unload macros when ready!"
+    SET_DISPLAY_TEXT MSG="Moving to filament change position, use load macros when ready!"
+    RESPOND TYPE=COMMAND MSG="Moving to filament change position, use load macros when ready!"
     PAUSE X={start_vars.filament_change_park_x} Y={start_vars.filament_change_park_y} Z_MIN={start_vars.filament_change_park_min_z} RESTORE=0
     _SAVE
-
+    UNLOAD_FILAMENT
 
 [gcode_macro _MAX_EXTRUDE_CHECK]
 gcode:


### PR DESCRIPTION
This suggestion is simply for user convenience. In my case, every time I change filament, I obviously have to unload the filament. I've thought about this, and I can't think of a single scenario where a filament change doesn't involve unloading the filament, so I added this line to my local copy, and it works like a charm. What do you think?

It could also be done with a variable, but I didn't include it because I think everyone would have it enabled.

Thanks.