### PR TITLE
Fix strange z-ascending at cleaning nozzle

### DIFF
--- a/Other_Files/DEMON_User_Files_SOURCE/demon_user_settings_cleaner_variables_v1.1.1.cfg
+++ b/Other_Files/DEMON_User_Files_SOURCE/demon_user_settings_cleaner_variables_v1.1.1.cfg
@@ -49,6 +49,8 @@ variable_park_x: 323.0                           # - SV08 Demon Purge Bucket X 3
 variable_park_y: 340.0                           # - SV08 Demon Purge Bucket Y 345, or for stock setup use 360
 variable_park_z: 25.0                            # - SV08 Demon Purge Bucket Z 25, or for stock setup use 25
 
+variable_z_safety_distance_before_cleaning: 10   # Distance to raise the toolhead before moving to the cleaner incase it’s been left low to the bed
+
 ## NOTE: To use Full linear cleaning mode set both random_clean_x & y options above to False!
 ## NOTE: If you set just one axis to linear mode but leave the other as radnom the priority settings are given to Random Cleaning Mode & 
 ## only the Linear Cleaning Mode linear_clean_start_x or y variables are used to set that axis' position.

--- a/demon_clean_load_v1.9.3.cfg
+++ b/demon_clean_load_v1.9.3.cfg
@@ -256,11 +256,9 @@ gcode:
       {% endif %}
     
       {% if clean_vars.random_clean_x == False and clean_vars.random_clean_y == False %}
-
-        {% if printer.toolhead.position.z|float < 10 %}
-          G0 Z10 F3600
+        {% if printer.toolhead.position.z|float < {clean_vars.z_safety_distance_before_cleaning|float} %}
+          G0 Z{clean_vars.z_safety_distance_before_cleaning|float} F3600
         {% endif %}
-
         G0 X{clean_vars.linear_clean_start_x|float} Y{clean_vars.linear_clean_start_y|float} F{clean_vars.clean_travel_speed * 60|int}
         G0 Z{clean_vars.linear_clean_start_z|float} F4000
         M400
@@ -277,11 +275,9 @@ gcode:
         {% endif %}
 
       {% elif clean_vars.random_clean_x == True or clean_vars.random_clean_y == True %}
-
-        {% if printer.toolhead.position.z|float < 10 %}
-          G0 Z10 F3600
+        {% if printer.toolhead.position.z|float < {clean_vars.z_safety_distance_before_cleaning|float} %}
+          G0 Z{clean_vars.z_safety_distance_before_cleaning|float} F3600
         {% endif %}
-
         G0 X{clean_vars.start_x|float} Y{clean_vars.start_y|float} F{clean_vars.clean_travel_speed * 60|int}
         G0 Z{clean_vars.start_z|float} F4000
         M400

--- a/demon_clean_load_v1.9.3.cfg
+++ b/demon_clean_load_v1.9.3.cfg
@@ -256,9 +256,7 @@ gcode:
       {% endif %}
     
       {% if clean_vars.random_clean_x == False and clean_vars.random_clean_y == False %}
-        {% if printer.toolhead.position.z|float < 20 %}
-          G0 Z20 F3600
-        {% endif %}
+
         G0 X{clean_vars.linear_clean_start_x|float} Y{clean_vars.linear_clean_start_y|float} F{clean_vars.clean_travel_speed * 60|int}
         G0 Z{clean_vars.linear_clean_start_z|float} F4000
         M400
@@ -275,9 +273,7 @@ gcode:
         {% endif %}
 
       {% elif clean_vars.random_clean_x == True or clean_vars.random_clean_y == True %}
-        {% if printer.toolhead.position.z|float < 20 %}
-          G0 Z20 F3600
-        {% endif %}
+
         G0 X{clean_vars.start_x|float} Y{clean_vars.start_y|float} F{clean_vars.clean_travel_speed * 60|int}
         G0 Z{clean_vars.start_z|float} F4000
         M400

--- a/demon_clean_load_v1.9.3.cfg
+++ b/demon_clean_load_v1.9.3.cfg
@@ -257,6 +257,7 @@ gcode:
     
       {% if clean_vars.random_clean_x == False and clean_vars.random_clean_y == False %}
         {% if printer.toolhead.position.z|float < {clean_vars.z_safety_distance_before_cleaning|float} %}
+          RESPOND TYPE=ECHO MSG="Toolhead is too close to the bed, raising it for safety"
           G0 Z{clean_vars.z_safety_distance_before_cleaning|float} F3600
         {% endif %}
         G0 X{clean_vars.linear_clean_start_x|float} Y{clean_vars.linear_clean_start_y|float} F{clean_vars.clean_travel_speed * 60|int}
@@ -276,6 +277,7 @@ gcode:
 
       {% elif clean_vars.random_clean_x == True or clean_vars.random_clean_y == True %}
         {% if printer.toolhead.position.z|float < {clean_vars.z_safety_distance_before_cleaning|float} %}
+          RESPOND TYPE=ECHO MSG="Toolhead is too close to the bed, raising it for safety"
           G0 Z{clean_vars.z_safety_distance_before_cleaning|float} F3600
         {% endif %}
         G0 X{clean_vars.start_x|float} Y{clean_vars.start_y|float} F{clean_vars.clean_travel_speed * 60|int}


### PR DESCRIPTION
After updating to version 2.9.6, when performing a LOAD_CLEAN, I noticed a strange movement in the Z direction just before brushing the nozzle. I reviewed the code and saw that a piece of code has been added inside the CLEAN_NOZZLE macro that does this:

```
{% if printer.toolhead.position.z|float < 20 %}
  G0 Z20 F3600
{% endif %}
```

What's the point of this code? Perhaps you meant "if printer.toolhead.position.z|float > 20"? In my case, it's acting strangely. I've attached a video:

https://github.com/user-attachments/assets/6b20d213-084d-40d5-a516-a401cba00df4

Thank you very much.