### PR TITLE
Update Other_Slicers.md (CURA START CODE IS INCORRECT)

### DIFF
--- a/Documentation/INSTALL_INSTRUCTIONS/Other_Slicers_Start_G-code/Other_Slicers.md
+++ b/Documentation/INSTALL_INSTRUCTIONS/Other_Slicers_Start_G-code/Other_Slicers.md
@@ -11,7 +11,7 @@ _SPS GSTART=True
 ```
 M109 S0
 M190 S0
-DEMON_START EXTRUDER=\{material_print_temperature_layer_0\} BED=\{material_bed_temperature_layer_0\} LAYER=\{layer_height\} FILAMENT=\{material_type\} DMGCC="v1.3"
+DEMON_START EXTRUDER=\{material_print_temperature_layer_0} BED=\{material_bed_temperature_layer_0} LAYER=\{layer_height} FILAMENT=\{material_type} DMGCC="v1.3"
 _SPS GSTART=True
 ```
 


### PR DESCRIPTION
The original CURA START GCODE will not work correctly! The extra "backslash" in each varible prevents the info being scooped out of the file.